### PR TITLE
Fix of `acme-staging`, sudo command, auto renewal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Usage
    export INFOMANIAK_API_TOKEN=xxx
    certbot certonly \
      --authenticator certbot-dns-infomaniak:dns-infomaniak \
-     --server https://acme-staging-v02.api.letsencrypt.org/directory \
+     --server https://acme-v02.api.letsencrypt.org/directory \
      --agree-tos \
      --rsa-key-size 4096 \
      -d 'death.star'

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,22 @@ If certbot requires elevated rights, the following command must be used instead:
      --rsa-key-size 4096 \
      -d 'death.star'
 
+Automatic renewal
+-----------------
+
+By default, certbot installs a service that periodically renews its
+certificates automatically. In order to do this, the command must know the API
+key, otherwise it will fail silently.
+
+In order to enable automatic renewal for your wildcard certificates, you will
+need to edit ``/lib/systemd/system/certbot.service``. In there, add the
+following line in ``Service``, with <YOUR_API_TOKEN> replaced with your actual
+token:
+
+.. code-block:: systemd
+
+   Environment="INFOMANIAK_API_TOKEN=<YOUR_API_TOKEN>"
+
 Acknowledgments
 ---------------
 

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ need to edit ``/lib/systemd/system/certbot.service``. In there, add the
 following line in ``Service``, with <YOUR_API_TOKEN> replaced with your actual
 token:
 
-.. code-block:: systemd
+::
 
    Environment="INFOMANIAK_API_TOKEN=<YOUR_API_TOKEN>"
 

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,18 @@ Usage
      --rsa-key-size 4096 \
      -d 'death.star'
 
+If certbot requires elevated rights, the following command must be used instead:
+
+.. code-block:: bash
+
+   export INFOMANIAK_API_TOKEN=xxx
+   sudo --preserve-env=INFOMANIAK_API_TOKEN certbot certonly \
+     --authenticator certbot-dns-infomaniak:dns-infomaniak \
+     --server https://acme-v02.api.letsencrypt.org/directory \
+     --agree-tos \
+     --rsa-key-size 4096 \
+     -d 'death.star'
+
 Acknowledgments
 ---------------
 


### PR DESCRIPTION
A few changes were made to the README file, one fix and two improvements:

- the original command used acme-staging-v02, which led to certificates being marked as TEST_CERT
- added a line to explain how to pass INFOMANIAK_API_TOKEN to `sudo`
- added instructions on how to enable auto renewal of the wildcard certificates by tweaking the certbot.service file