### PR TITLE
Down to 0.31 for buster compat

### DIFF
--- a/certbot_dns_infomaniak/dns_infomaniak.py
+++ b/certbot_dns_infomaniak/dns_infomaniak.py
@@ -8,7 +8,10 @@ import zope.interface
 from certbot import errors
 from certbot import interfaces
 from certbot.plugins import dns_common
-import certbot.compat.os as os
+try:
+    import certbot.compat.os as os
+except ImportError:
+    import os
 
 logger = logging.getLogger(__name__)
 

--- a/certbot_dns_infomaniak/dns_infomaniak_test.py
+++ b/certbot_dns_infomaniak/dns_infomaniak_test.py
@@ -7,7 +7,10 @@ import mock
 import requests_mock
 
 from certbot.errors import PluginError
-import certbot.compat.os as os
+try:
+    import certbot.compat.os as os
+except ImportError:
+    import os
 from certbot.plugins import dns_test_common
 from certbot.plugins.dns_test_common import DOMAIN
 from certbot.tests import util as test_util

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-certbot>=0.34.0
+certbot>=0.31.0
 setuptools
 requests
 mock

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from os import path
 version = "0.0.0"
 
 install_requires = [
-    "certbot>=0.34.0",
+    "certbot>=0.31.0",
     "setuptools",
     "requests",
     "mock",


### PR DESCRIPTION
0.34 is not shipped with debian buster, forcing reinstall from pip

Fixes #9