### PR TITLE
remove extraneous/obsolete dependence on 'mock'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ install_requires = [
     "certbot>=0.31.0",
     "setuptools",
     "requests",
-    "mock",
     "requests-mock",
     "idna",
 ]


### PR DESCRIPTION
your package is using 'unittest.mock'