### PR TITLE
fix: use seach filter to prevent retrieving all zone records

### DIFF
--- a/certbot_dns_infomaniak/dns_infomaniak.py
+++ b/certbot_dns_infomaniak/dns_infomaniak.py
@@ -178,7 +178,7 @@ class _APIDomain:
                     and x["type"] == record["type"]
                     and x["target"] == record["target"]
                 ),
-                self._get_request("/1/domain/{domain_id}/dns/record".format(domain_id=domain_id)),
+                self._get_request("/1/domain/{domain_id}/dns/record?search={fqdn}".format(domain_id=domain_id, fqdn=fqdn)),
             )
         )
 

--- a/certbot_dns_infomaniak/dns_infomaniak.py
+++ b/certbot_dns_infomaniak/dns_infomaniak.py
@@ -178,7 +178,7 @@ class _APIDomain:
                     and x["type"] == record["type"]
                     and x["target"] == record["target"]
                 ),
-                self._get_request("/1/domain/{domain_id}/dns/record?search={fqdn}".format(domain_id=domain_id, fqdn=fqdn)),
+                self._get_request("/1/domain/{domain_id}/dns/record?search={fqdn}&filter[types][]={type}".format(domain_id=domain_id, fqdn=fqdn, type=record["type"])),
             )
         )
 


### PR DESCRIPTION
by adding `search` query parameter to the `/1/domain/{domain_id}/dns/record` route, we retrieve only the records matching this record
we also add the `filter[types][]=...` param to fetch only needed records by type
