### PR TITLE
Fix: Post request were done without Content-Type headers

### DIFF
--- a/certbot_dns_infomaniak/dns_infomaniak.py
+++ b/certbot_dns_infomaniak/dns_infomaniak.py
@@ -119,8 +119,10 @@ class _APIDomain:
         :param dict payload : body of request
         """
         url = self.baseUrl + url
+        headers = {"Content-Type": "application/json"}
+        json_data = json.dumps(payload)
         logger.debug("POST %s", url)
-        with self.session.post(url, data=payload) as req:
+        with self.session.post(url, data=json_data, headers=headers) as req:
             try:
                 result = req.json()
             except json.decoder.JSONDecodeError as exc:


### PR DESCRIPTION
It's the fix i done fixing issue  #40 

It's tested on our server and was working, but beeing not a python dev, this might not be the good way to do it