### PR TITLE
Narrows down the required scopes for the token generation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@ This plugin enables usage of Infomaniak public API to complete ``dns-01`` challe
 Issue a token
 -------------
 
-At your Infomaniak manager dashboard_, to to the API section and generate a token
-with "Domain" scope
+At your Infomaniak manager dashboard_, to the API section and generate a token
+with " domain:read", " dns:read" and " dns:write" scopes.
 
 .. _dashboard: https://manager.infomaniak.com/v3/infomaniak-api
 


### PR DESCRIPTION
After looking at the token generation scopes, it seems the full "Domain" scope could be broader than required.
After observing the references to [`_get_request`](https://github.com/Infomaniak/certbot-dns-infomaniak/blob/main/certbot_dns_infomaniak/dns_infomaniak.py#L92) and  [`_post_request`](https://github.com/Infomaniak/certbot-dns-infomaniak/blob/main/certbot_dns_infomaniak/dns_infomaniak.py#L115), it seems that there are "reads" for the domain_id and for the records to observe existing TXT records, while there are "writes" to add and delete records related to the DNS-01 challenge.

After testing, generating a token with these scopes allows to successfully generate new certificates with the certbot. However, after testing, it does not seem that these scopes are enforced yet as I could read domain id and records with a few randomly selected scopes (AI tools, SMS, Video notably) without requiring the `domain:read` or `dns:read` scopes. Probably the presence of the adequate scopes will be enforced in the future, so it might be helpful to make this documentation as precise as possible. 